### PR TITLE
feat(kafka): configuracion inicial kafka y contenedores docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  postgres:
+    image: postgres:latest
+    container_name: postgres
+    environment:
+      POSTGRES_DB: geosense_db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST_AUTH_METHOD: password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,10 @@
 		    <version>2.0.2</version>
 		    <scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>org.springframework.kafka</groupId>
+		    <artifactId>spring-kafka</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/geosense/config/KafkaConfig.java
+++ b/src/main/java/com/geosense/config/KafkaConfig.java
@@ -1,0 +1,55 @@
+package com.geosense.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, "geosense-group");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = 
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public NewTopic geoSenseTopic() {
+        return new NewTopic("geosense-topic", 1, (short) 1);
+    }
+}

--- a/src/main/java/com/geosense/controller/KafkaController.java
+++ b/src/main/java/com/geosense/controller/KafkaController.java
@@ -1,0 +1,19 @@
+package com.geosense.controller;
+
+import com.geosense.service.KafkaProducerService;
+import org.springframework.web.bind.annotation.*;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/kafka")
+@RequiredArgsConstructor
+public class KafkaController {
+
+    private final KafkaProducerService producerService;
+
+    @PostMapping("/publish")
+    public String publishMessage(@RequestBody String message) {
+        producerService.sendMessage("geosense-topic", message);
+        return "Message sent successfully";
+    }
+}

--- a/src/main/java/com/geosense/service/KafkaConsumerService.java
+++ b/src/main/java/com/geosense/service/KafkaConsumerService.java
@@ -1,0 +1,16 @@
+package com.geosense.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class KafkaConsumerService {
+
+    @KafkaListener(topics = "geosense-topic", groupId = "geosense-group")
+    public void listen(String message) {
+        log.info("Received message: {}", message);
+        // Agregar lógica de procesamiento de mensajes aquí
+    }
+}

--- a/src/main/java/com/geosense/service/KafkaProducerService.java
+++ b/src/main/java/com/geosense/service/KafkaProducerService.java
@@ -1,0 +1,30 @@
+package com.geosense.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@Slf4j
+public class KafkaProducerService {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public KafkaProducerService(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendMessage(String topic, String message) {
+        CompletableFuture<SendResult<String, String>> future = kafkaTemplate.send(topic, message);
+        
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                System.out.println("Message sent successfully");
+            } else {
+                System.out.println("Error sending message: " + ex.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,8 @@ spring.datasource.hikari.connection-timeout=20000
 spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.consumer.group-id=geosense-group
 spring.kafka.consumer.auto-offset-reset=earliest
+
+# JPA/Hibernate properties
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,11 +6,17 @@ spring.security.user.password=admin123
 spring.security.user.roles=ADMIN
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.datasource.url=jdbc:postgresql://localhost:5432/geosense_db
+# Database Configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/geosense_db?currentSchema=public
 spring.datasource.username=postgres
 spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
 
-# Config de Hibernate (JPA)
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+# Additional connection properties
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.connection-timeout=20000
+
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=geosense-group
+spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
### Prerequisitos
1. Instalar Java 21 
2. Instalar Docker Desktop
3. Instalar Maven

### Proceso para correr proyecto
1. Iniciar contenedores para Kafka y PostgresSQL en Docker: 
`docker-compose up -d`

3. Verificar que los contenedores están corriendo: 
`docker ps`
 Debería verse una lista donde aparece Kafka, Postgres y Zookeper.

5. Hacer build del proyecto:
`mvn clean install`

7. Correr la aplicación: 
`mvn spring-boot:run`

9. Probar endpoints en postman.

11. Verificar integración de kafka: `docker exec -it kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic geosense-topic --from-beginning` ( este paso todavía no lo entiendo del todo, ya que si está funcionando correctamente debería mostrar un mensaje pero no cacho bien cómo crearlo al abrir la rama desde otro compu )

Por lo que entiendo, esto es lo que se verifica de Kafka:
- El producer envío el mensaje exitosamente
- Kafka lo recibió y guardó
- El mensaje puede ser leído por cualquier consumer